### PR TITLE
Upstream some fixes

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -50,7 +50,7 @@ object cask extends ScalaModule with PublishModule {
 
     def testFrameworks = Seq("utest.runner.Framework")
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
 //      ivy"org.xerial:sqlite-jdbc:3.18.0",
 //      ivy"io.getquill::quill-jdbc:2.6.0"

--- a/cask/src/cask/decorators/compress.scala
+++ b/cask/src/cask/decorators/compress.scala
@@ -6,7 +6,7 @@ import cask.internal.Router
 import cask.model.{Request, Response}
 
 import collection.JavaConverters._
-class compress extends cask.Decorator{
+class compress extends cask.RawDecorator{
   def wrapFunction(ctx: Request, delegate: Delegate) = {
     val acceptEncodings = ctx.exchange.getRequestHeaders.get("Accept-Encoding").asScala.flatMap(_.split(", "))
     delegate(Map()).map{ v =>

--- a/cask/src/cask/endpoints/FormEndpoint.scala
+++ b/cask/src/cask/endpoints/FormEndpoint.scala
@@ -44,13 +44,13 @@ object FormReader{
   }
 }
 class postForm(val path: String, override val subpath: Boolean = false) extends Endpoint {
-  type Output = Response
+  type InnerReturned = Response.Raw
 
   val methods = Seq("post")
   type Input = Seq[FormEntry]
   type InputParser[T] = FormReader[T]
   def wrapFunction(ctx: Request,
-                       delegate: Map[String, Input] => Router.Result[Output]): Router.Result[Response] = {
+                       delegate: Delegate): Router.Result[Response.Raw] = {
     try {
       val formData = FormParserFactory.builder().build().createParser(ctx.exchange).parseBlocking()
       delegate(
@@ -62,7 +62,8 @@ class postForm(val path: String, override val subpath: Boolean = false) extends 
       )
     } catch{case e: Exception =>
       Router.Result.Success(cask.model.Response(
-        "Unable to parse form data: " + e + "\n" + Util.stackTraceString(e)
+        "Unable to parse form data: " + e + "\n" + Util.stackTraceString(e),
+        statusCode = 400
       ))
     }
   }

--- a/cask/src/cask/endpoints/FormEndpoint.scala
+++ b/cask/src/cask/endpoints/FormEndpoint.scala
@@ -43,8 +43,8 @@ object FormReader{
     def read(ctx: Request, label: String, input: Seq[FormEntry]) = input.map(_.asInstanceOf[FormFile])
   }
 }
-class postForm(val path: String, override val subpath: Boolean = false) extends Endpoint {
-  type InnerReturned = Response.Raw
+class postForm(val path: String, override val subpath: Boolean = false)
+  extends Endpoint[Response.Raw] {
 
   val methods = Seq("post")
   type Input = Seq[FormEntry]

--- a/cask/src/cask/endpoints/FormEndpoint.scala
+++ b/cask/src/cask/endpoints/FormEndpoint.scala
@@ -1,7 +1,7 @@
 package cask.endpoints
 
 import cask.internal.{Router, Util}
-import cask.main.Endpoint
+import cask.main.HttpEndpoint
 import cask.model._
 import io.undertow.server.handlers.form.FormParserFactory
 
@@ -44,7 +44,7 @@ object FormReader{
   }
 }
 class postForm(val path: String, override val subpath: Boolean = false)
-  extends Endpoint[Response.Raw, Seq[FormEntry]] {
+  extends HttpEndpoint[Response.Raw, Seq[FormEntry]] {
 
   val methods = Seq("post")
   type InputParser[T] = FormReader[T]

--- a/cask/src/cask/endpoints/FormEndpoint.scala
+++ b/cask/src/cask/endpoints/FormEndpoint.scala
@@ -44,10 +44,9 @@ object FormReader{
   }
 }
 class postForm(val path: String, override val subpath: Boolean = false)
-  extends Endpoint[Response.Raw] {
+  extends Endpoint[Response.Raw, Seq[FormEntry]] {
 
   val methods = Seq("post")
-  type Input = Seq[FormEntry]
   type InputParser[T] = FormReader[T]
   def wrapFunction(ctx: Request,
                        delegate: Delegate): Router.Result[Response.Raw] = {
@@ -68,6 +67,6 @@ class postForm(val path: String, override val subpath: Boolean = false)
     }
   }
 
-  def wrapPathSegment(s: String): Input = Seq(FormValue(s, new io.undertow.util.HeaderMap))
+  def wrapPathSegment(s: String): Seq[FormEntry] = Seq(FormValue(s, new io.undertow.util.HeaderMap))
 }
 

--- a/cask/src/cask/endpoints/JsonEndpoint.scala
+++ b/cask/src/cask/endpoints/JsonEndpoint.scala
@@ -40,9 +40,8 @@ object JsonData extends DataCompanion[JsonData]{
 }
 
 class postJson(val path: String, override val subpath: Boolean = false)
-  extends Endpoint[Response[JsonData]]{
+  extends Endpoint[Response[JsonData], ujson.Value]{
   val methods = Seq("post")
-  type Input = ujson.Value
   type InputParser[T] = JsReader[T]
   override type OuterReturned = Router.Result[Response.Raw]
   def wrapFunction(ctx: Request,
@@ -76,13 +75,12 @@ class postJson(val path: String, override val subpath: Boolean = false)
       case Right(params) => delegate(params)
     }
   }
-  def wrapPathSegment(s: String): Input = ujson.Str(s)
+  def wrapPathSegment(s: String): ujson.Value = ujson.Str(s)
 }
 
 class getJson(val path: String, override val subpath: Boolean = false)
-  extends Endpoint[Response[JsonData]]{
+  extends Endpoint[Response[JsonData], Seq[String]]{
   val methods = Seq("get")
-  type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   override type OuterReturned = Router.Result[Response.Raw]
   def wrapFunction(ctx: Request, delegate: Delegate): Router.Result[Response.Raw] = {

--- a/cask/src/cask/endpoints/JsonEndpoint.scala
+++ b/cask/src/cask/endpoints/JsonEndpoint.scala
@@ -1,11 +1,11 @@
 package cask.endpoints
 
-import java.io.ByteArrayOutputStream
+import java.io.{ByteArrayOutputStream, InputStream, OutputStream, OutputStreamWriter}
 
 import cask.internal.{Router, Util}
 import cask.main.Endpoint
 import cask.model.{Request, Response}
-
+import collection.JavaConverters._
 
 sealed trait JsReader[T] extends Router.ArgReader[ujson.Value, T, cask.model.Request]
 object JsReader{
@@ -26,13 +26,25 @@ object JsReader{
     }
   }
 }
+trait JsonData extends Response.Data
+object JsonData{
+  implicit class JsonDataImpl[T: upickle.default.Writer](t: T) extends JsonData{
+    def write(out: OutputStream) = {
+      val writer = new OutputStreamWriter(out)
+      implicitly[upickle.default.Writer[T]].write(new ujson.BaseRenderer(writer), t)
+      writer.flush()
+    }
+  }
+}
+
 class postJson(val path: String, override val subpath: Boolean = false) extends Endpoint{
-  type Output = Response
+  type InnerReturned = Response[JsonData]
   val methods = Seq("post")
-  type Input = ujson.Js.Value
+  type Input = ujson.Value
   type InputParser[T] = JsReader[T]
+  override type OuterReturned = Router.Result[Response.Raw]
   def wrapFunction(ctx: Request,
-                       delegate: Map[String, Input] => Router.Result[Output]): Router.Result[Response] = {
+                   delegate: Delegate): Router.Result[Response.Raw] = {
     val obj = for{
       str <-
         try {
@@ -41,21 +53,42 @@ class postJson(val path: String, override val subpath: Boolean = false) extends 
           Right(new String(boas.toByteArray))
         }
         catch{case e: Throwable => Left(cask.model.Response(
-          "Unable to deserialize input JSON text: " + e + "\n" + Util.stackTraceString(e)
+          "Unable to deserialize input JSON text: " + e + "\n" + Util.stackTraceString(e),
+          statusCode = 400
         ))}
       json <-
         try Right(ujson.read(str))
         catch{case e: Throwable => Left(cask.model.Response(
-          "Input text is invalid JSON: " + e + "\n" + Util.stackTraceString(e)
+          "Input text is invalid JSON: " + e + "\n" + Util.stackTraceString(e),
+          statusCode = 400
         ))}
       obj <-
         try Right(json.obj)
-        catch {case e: Throwable => Left(cask.model.Response("Input JSON must be a dictionary"))}
+        catch {case e: Throwable => Left(cask.model.Response(
+          "Input JSON must be a dictionary",
+          statusCode = 400
+        ))}
     } yield obj.toMap
     obj match{
-      case Left(r) => Router.Result.Success(r)
-      case Right(params) => delegate(params)
+      case Left(r) => Router.Result.Success(r.map(Response.Data.StringData))
+      case Right(params) => delegate(params).map(_.data)
     }
   }
-  def wrapPathSegment(s: String): Input = ujson.Js.Str(s)
+  def wrapPathSegment(s: String): Input = ujson.Str(s)
+}
+
+class getJson(val path: String, override val subpath: Boolean = false) extends Endpoint{
+  type InnerReturned = Response[JsonData]
+  val methods = Seq("get")
+  type Input = Seq[String]
+  type InputParser[T] = QueryParamReader[T]
+  override type OuterReturned = Router.Result[Response.Raw]
+  def wrapFunction(ctx: Request,
+                   delegate: Delegate): Router.Result[Response.Raw] = {
+
+    val res = delegate(WebEndpoint.buildMapFromQueryParams(ctx))
+
+    res.map(_.data)
+  }
+  def wrapPathSegment(s: String) = Seq(s)
 }

--- a/cask/src/cask/endpoints/JsonEndpoint.scala
+++ b/cask/src/cask/endpoints/JsonEndpoint.scala
@@ -39,8 +39,8 @@ object JsonData extends DataCompanion[JsonData]{
   }
 }
 
-class postJson(val path: String, override val subpath: Boolean = false) extends Endpoint{
-  type InnerReturned = Response[JsonData]
+class postJson(val path: String, override val subpath: Boolean = false)
+  extends Endpoint[Response[JsonData]]{
   val methods = Seq("post")
   type Input = ujson.Value
   type InputParser[T] = JsReader[T]
@@ -79,8 +79,8 @@ class postJson(val path: String, override val subpath: Boolean = false) extends 
   def wrapPathSegment(s: String): Input = ujson.Str(s)
 }
 
-class getJson(val path: String, override val subpath: Boolean = false) extends Endpoint{
-  type InnerReturned = Response[JsonData]
+class getJson(val path: String, override val subpath: Boolean = false)
+  extends Endpoint[Response[JsonData]]{
   val methods = Seq("get")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]

--- a/cask/src/cask/endpoints/JsonEndpoint.scala
+++ b/cask/src/cask/endpoints/JsonEndpoint.scala
@@ -3,7 +3,7 @@ package cask.endpoints
 import java.io.{ByteArrayOutputStream, InputStream, OutputStream, OutputStreamWriter}
 
 import cask.internal.{Router, Util}
-import cask.main.Endpoint
+import cask.main.HttpEndpoint
 import cask.model.Response.DataCompanion
 import cask.model.{Request, Response}
 
@@ -40,7 +40,7 @@ object JsonData extends DataCompanion[JsonData]{
 }
 
 class postJson(val path: String, override val subpath: Boolean = false)
-  extends Endpoint[Response[JsonData], ujson.Value]{
+  extends HttpEndpoint[Response[JsonData], ujson.Value]{
   val methods = Seq("post")
   type InputParser[T] = JsReader[T]
   override type OuterReturned = Router.Result[Response.Raw]
@@ -79,7 +79,7 @@ class postJson(val path: String, override val subpath: Boolean = false)
 }
 
 class getJson(val path: String, override val subpath: Boolean = false)
-  extends Endpoint[Response[JsonData], Seq[String]]{
+  extends HttpEndpoint[Response[JsonData], Seq[String]]{
   val methods = Seq("get")
   type InputParser[T] = QueryParamReader[T]
   override type OuterReturned = Router.Result[Response.Raw]

--- a/cask/src/cask/endpoints/StaticEndpoints.scala
+++ b/cask/src/cask/endpoints/StaticEndpoints.scala
@@ -3,9 +3,8 @@ package cask.endpoints
 import cask.main.Endpoint
 import cask.model.Request
 
-class staticFiles(val path: String) extends Endpoint[String]{
+class staticFiles(val path: String) extends Endpoint[String, Seq[String]]{
   val methods = Seq("get")
-  type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   override def subpath = true
   def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
@@ -18,13 +17,12 @@ class staticFiles(val path: String) extends Endpoint[String]{
     )
   }
 
-  def wrapPathSegment(s: String): Input = Seq(s)
+  def wrapPathSegment(s: String): Seq[String] = Seq(s)
 }
 
 class staticResources(val path: String, resourceRoot: ClassLoader = getClass.getClassLoader)
-  extends Endpoint[String]{
+  extends Endpoint[String, Seq[String]]{
   val methods = Seq("get")
-  type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   override def subpath = true
   def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
@@ -38,5 +36,5 @@ class staticResources(val path: String, resourceRoot: ClassLoader = getClass.get
     )
   }
 
-  def wrapPathSegment(s: String): Input = Seq(s)
+  def wrapPathSegment(s: String): Seq[String] = Seq(s)
 }

--- a/cask/src/cask/endpoints/StaticEndpoints.scala
+++ b/cask/src/cask/endpoints/StaticEndpoints.scala
@@ -1,9 +1,9 @@
 package cask.endpoints
 
-import cask.main.Endpoint
+import cask.main.HttpEndpoint
 import cask.model.Request
 
-class staticFiles(val path: String) extends Endpoint[String, Seq[String]]{
+class staticFiles(val path: String) extends HttpEndpoint[String, Seq[String]]{
   val methods = Seq("get")
   type InputParser[T] = QueryParamReader[T]
   override def subpath = true
@@ -21,7 +21,7 @@ class staticFiles(val path: String) extends Endpoint[String, Seq[String]]{
 }
 
 class staticResources(val path: String, resourceRoot: ClassLoader = getClass.getClassLoader)
-  extends Endpoint[String, Seq[String]]{
+  extends HttpEndpoint[String, Seq[String]]{
   val methods = Seq("get")
   type InputParser[T] = QueryParamReader[T]
   override def subpath = true

--- a/cask/src/cask/endpoints/StaticEndpoints.scala
+++ b/cask/src/cask/endpoints/StaticEndpoints.scala
@@ -3,8 +3,7 @@ package cask.endpoints
 import cask.main.Endpoint
 import cask.model.Request
 
-class staticFiles(val path: String) extends Endpoint{
-  type InnerReturned = String
+class staticFiles(val path: String) extends Endpoint[String]{
   val methods = Seq("get")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
@@ -22,8 +21,8 @@ class staticFiles(val path: String) extends Endpoint{
   def wrapPathSegment(s: String): Input = Seq(s)
 }
 
-class staticResources(val path: String, resourceRoot: ClassLoader = getClass.getClassLoader) extends Endpoint{
-  type InnerReturned = String
+class staticResources(val path: String, resourceRoot: ClassLoader = getClass.getClassLoader)
+  extends Endpoint[String]{
   val methods = Seq("get")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]

--- a/cask/src/cask/endpoints/StaticEndpoints.scala
+++ b/cask/src/cask/endpoints/StaticEndpoints.scala
@@ -4,12 +4,12 @@ import cask.main.Endpoint
 import cask.model.Request
 
 class staticFiles(val path: String) extends Endpoint{
-  type Output = String
+  type InnerReturned = String
   val methods = Seq("get")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   override def subpath = true
-  def wrapFunction(ctx: Request, delegate: Delegate): Returned = {
+  def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
     delegate(Map()).map(t =>
       cask.model.StaticFile(
         (cask.internal.Util.splitPath(t) ++ ctx.remainingPathSegments)
@@ -23,12 +23,12 @@ class staticFiles(val path: String) extends Endpoint{
 }
 
 class staticResources(val path: String, resourceRoot: ClassLoader = getClass.getClassLoader) extends Endpoint{
-  type Output = String
+  type InnerReturned = String
   val methods = Seq("get")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   override def subpath = true
-  def wrapFunction(ctx: Request, delegate: Delegate): Returned = {
+  def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
     delegate(Map()).map(t =>
       cask.model.StaticResource(
         (cask.internal.Util.splitPath(t) ++ ctx.remainingPathSegments)

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -7,8 +7,7 @@ import cask.model.{Request, Response}
 import collection.JavaConverters._
 
 
-trait WebEndpoint extends Endpoint[Response.Raw]{
-  type Input = Seq[String]
+trait WebEndpoint extends Endpoint[Response.Raw, Seq[String]]{
   type InputParser[T] = QueryParamReader[T]
   def wrapFunction(ctx: Request,
                        delegate: Delegate): Router.Result[Response.Raw] = {

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -1,13 +1,13 @@
 package cask.endpoints
 
 import cask.internal.Router
-import cask.main.Endpoint
+import cask.main.HttpEndpoint
 import cask.model.{Request, Response}
 
 import collection.JavaConverters._
 
 
-trait WebEndpoint extends Endpoint[Response.Raw, Seq[String]]{
+trait WebEndpoint extends HttpEndpoint[Response.Raw, Seq[String]]{
   type InputParser[T] = QueryParamReader[T]
   def wrapFunction(ctx: Request,
                        delegate: Delegate): Router.Result[Response.Raw] = {

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -8,12 +8,17 @@ import collection.JavaConverters._
 
 
 trait WebEndpoint extends Endpoint{
-  type Output = Response
+  type InnerReturned = Response.Raw
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   def wrapFunction(ctx: Request,
-                       delegate: Map[String, Input] => Router.Result[Output]): Router.Result[Response] = {
-
+                       delegate: Delegate): Router.Result[Response.Raw] = {
+    delegate(WebEndpoint.buildMapFromQueryParams(ctx))
+  }
+  def wrapPathSegment(s: String) = Seq(s)
+}
+object WebEndpoint{
+  def buildMapFromQueryParams(ctx: Request) = {
     val b = Map.newBuilder[String, Seq[String]]
     val queryParams = ctx.exchange.getQueryParameters
     for(k <- queryParams.keySet().iterator().asScala){
@@ -22,9 +27,8 @@ trait WebEndpoint extends Endpoint{
       deque.toArray(arr)
       b += (k -> (arr: Seq[String]))
     }
-    delegate(b.result())
+    b.result()
   }
-  def wrapPathSegment(s: String) = Seq(s)
 }
 class get(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("get")

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -7,8 +7,7 @@ import cask.model.{Request, Response}
 import collection.JavaConverters._
 
 
-trait WebEndpoint extends Endpoint{
-  type InnerReturned = Response.Raw
+trait WebEndpoint extends Endpoint[Response.Raw]{
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   def wrapFunction(ctx: Request,

--- a/cask/src/cask/endpoints/WebSocketEndpoint.scala
+++ b/cask/src/cask/endpoints/WebSocketEndpoint.scala
@@ -13,8 +13,8 @@ object WebsocketResult{
   implicit class Listener(val value: WebSocketConnectionCallback) extends WebsocketResult
 }
 
-class websocket(val path: String, override val subpath: Boolean = false) extends cask.main.BaseEndpoint{
-  type InnerReturned = WebsocketResult
+class websocket(val path: String, override val subpath: Boolean = false)
+  extends cask.main.BaseEndpoint[WebsocketResult]{
   val methods = Seq("websocket")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]

--- a/cask/src/cask/endpoints/WebSocketEndpoint.scala
+++ b/cask/src/cask/endpoints/WebSocketEndpoint.scala
@@ -14,7 +14,7 @@ object WebsocketResult{
 }
 
 class websocket(val path: String, override val subpath: Boolean = false)
-  extends cask.main.BaseEndpoint[WebsocketResult, Seq[String]]{
+  extends cask.main.Endpoint[WebsocketResult, Seq[String]]{
   val methods = Seq("websocket")
   type InputParser[T] = QueryParamReader[T]
   type OuterReturned = Router.Result[WebsocketResult]

--- a/cask/src/cask/endpoints/WebSocketEndpoint.scala
+++ b/cask/src/cask/endpoints/WebSocketEndpoint.scala
@@ -14,14 +14,13 @@ object WebsocketResult{
 }
 
 class websocket(val path: String, override val subpath: Boolean = false)
-  extends cask.main.BaseEndpoint[WebsocketResult]{
+  extends cask.main.BaseEndpoint[WebsocketResult, Seq[String]]{
   val methods = Seq("websocket")
-  type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
   type OuterReturned = Router.Result[WebsocketResult]
   def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
     delegate(WebEndpoint.buildMapFromQueryParams(ctx))
   }
 
-  def wrapPathSegment(s: String): Input = Seq(s)
+  def wrapPathSegment(s: String): Seq[String] = Seq(s)
 }

--- a/cask/src/cask/endpoints/WebSocketEndpoint.scala
+++ b/cask/src/cask/endpoints/WebSocketEndpoint.scala
@@ -3,22 +3,25 @@ package cask.endpoints
 import cask.internal.Router
 import cask.model.Request
 import io.undertow.websockets.WebSocketConnectionCallback
-
+import collection.JavaConverters._
 sealed trait WebsocketResult
 object WebsocketResult{
-  implicit class Response(val value: cask.model.Response) extends WebsocketResult
+  implicit class Response[T](value0: cask.model.Response[T])
+                            (implicit f: T => cask.model.Response.Data) extends WebsocketResult{
+    def value = value0.map(f)
+  }
   implicit class Listener(val value: WebSocketConnectionCallback) extends WebsocketResult
 }
 
 class websocket(val path: String, override val subpath: Boolean = false) extends cask.main.BaseEndpoint{
-  type Output = WebsocketResult
+  type InnerReturned = WebsocketResult
   val methods = Seq("websocket")
   type Input = Seq[String]
   type InputParser[T] = QueryParamReader[T]
-  type Returned = Router.Result[WebsocketResult]
-  def wrapFunction(ctx: Request, delegate: Delegate): Returned = delegate(Map())
+  type OuterReturned = Router.Result[WebsocketResult]
+  def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
+    delegate(WebEndpoint.buildMapFromQueryParams(ctx))
+  }
 
   def wrapPathSegment(s: String): Input = Seq(s)
-
-
 }

--- a/cask/src/cask/internal/Conversion.scala
+++ b/cask/src/cask/internal/Conversion.scala
@@ -1,0 +1,9 @@
+package cask.internal
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Cannot return ${T} as a ${V} response")
+class Conversion[T, V](val f: T => V)
+object Conversion{
+  def create[T, V](implicit f: T => V) = new Conversion(f)
+}

--- a/cask/src/cask/internal/Conversion.scala
+++ b/cask/src/cask/internal/Conversion.scala
@@ -2,8 +2,8 @@ package cask.internal
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound("Cannot return ${T} as a ${V} response")
+@implicitNotFound("Cannot return ${T} as a ${V}")
 class Conversion[T, V](val f: T => V)
 object Conversion{
-  def create[T, V](implicit f: T => V) = new Conversion(f)
+  implicit def create[T, V](implicit f: T => V) = new Conversion(f)
 }

--- a/cask/src/cask/internal/Util.scala
+++ b/cask/src/cask/internal/Util.scala
@@ -7,9 +7,14 @@ import scala.collection.mutable
 import java.io.OutputStream
 
 import scala.annotation.switch
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 object Util {
-
+  def firstFutureOf[T](futures: Seq[Future[T]])(implicit ec: ExecutionContext) = {
+    val p = Promise[T]
+    futures.foreach(_.foreach(p.trySuccess))
+    p.future
+  }
   /**
     * Convert a string to a C&P-able literal. Basically
     * copied verbatim from the uPickle source code.

--- a/cask/src/cask/main/Decorators.scala
+++ b/cask/src/cask/main/Decorators.scala
@@ -9,7 +9,7 @@ import cask.model.{Request, Response}
   * Annotates a Cask endpoint that returns a HTTP [[Response]]; similar to a
   * [[Decorator]] but with additional metadata and capabilities.
   */
-trait Endpoint[InnerReturned] extends BaseEndpoint[InnerReturned] {
+trait Endpoint[InnerReturned, Input] extends BaseEndpoint[InnerReturned, Input] {
   type OuterReturned = Router.Result[Response.Raw]
 }
 
@@ -17,7 +17,7 @@ trait Endpoint[InnerReturned] extends BaseEndpoint[InnerReturned] {
   * An [[Endpoint]] that may return something else than a HTTP response, e.g.
   * a websocket endpoint which may instead return a websocket event handler
   */
-trait BaseEndpoint[InnerReturned] extends BaseDecorator[InnerReturned]{
+trait BaseEndpoint[InnerReturned, Input] extends BaseDecorator[InnerReturned, Input]{
   /**
     * What is the path that this particular endpoint matches?
     */
@@ -55,10 +55,10 @@ trait BaseEndpoint[InnerReturned] extends BaseDecorator[InnerReturned]{
 /**
   * A [[Decorator]] that may deal with values other than HTTP [[Response]]s
   */
-trait BaseDecorator[InnerReturned]{
-  type Input
+trait BaseDecorator[InnerReturned, Input]{
+  final type InputTypeAlias = Input
   type InputParser[T] <: ArgReader[Input, T, Request]
-  type Delegate = Map[String, Input] => Router.Result[InnerReturned]
+  final type Delegate = Map[String, Input] => Router.Result[InnerReturned]
   type OuterReturned <: Router.Result[Any]
   def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned
   def getParamParser[T](implicit p: InputParser[T]) = p
@@ -75,10 +75,9 @@ trait BaseDecorator[InnerReturned]{
   * to `wrapFunction`, which takes a `Map` representing any additional argument
   * lists (if any).
   */
-trait Decorator extends BaseDecorator[Response.Raw]{
+trait Decorator extends BaseDecorator[Response.Raw, Any]{
   type OuterReturned = Router.Result[Response.Raw]
-  type Input = Any
-  type InputParser[T] = NoOpParser[Input, T]
+  type InputParser[T] = NoOpParser[Any, T]
 }
 
 class NoOpParser[Input, T] extends ArgReader[Input, T, Request] {

--- a/cask/src/cask/main/Decorators.scala
+++ b/cask/src/cask/main/Decorators.scala
@@ -9,7 +9,7 @@ import cask.model.{Request, Response}
   * Annotates a Cask endpoint that returns a HTTP [[Response]]; similar to a
   * [[Decorator]] but with additional metadata and capabilities.
   */
-trait Endpoint extends BaseEndpoint {
+trait Endpoint[InnerReturned] extends BaseEndpoint[InnerReturned] {
   type OuterReturned = Router.Result[Response.Raw]
 }
 
@@ -17,7 +17,7 @@ trait Endpoint extends BaseEndpoint {
   * An [[Endpoint]] that may return something else than a HTTP response, e.g.
   * a websocket endpoint which may instead return a websocket event handler
   */
-trait BaseEndpoint extends BaseDecorator{
+trait BaseEndpoint[InnerReturned] extends BaseDecorator[InnerReturned]{
   /**
     * What is the path that this particular endpoint matches?
     */
@@ -55,10 +55,9 @@ trait BaseEndpoint extends BaseDecorator{
 /**
   * A [[Decorator]] that may deal with values other than HTTP [[Response]]s
   */
-trait BaseDecorator{
+trait BaseDecorator[InnerReturned]{
   type Input
   type InputParser[T] <: ArgReader[Input, T, Request]
-  type InnerReturned
   type Delegate = Map[String, Input] => Router.Result[InnerReturned]
   type OuterReturned <: Router.Result[Any]
   def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned
@@ -76,10 +75,9 @@ trait BaseDecorator{
   * to `wrapFunction`, which takes a `Map` representing any additional argument
   * lists (if any).
   */
-trait Decorator extends BaseDecorator{
+trait Decorator extends BaseDecorator[Response.Raw]{
   type OuterReturned = Router.Result[Response.Raw]
   type Input = Any
-  type InnerReturned = Response.Raw
   type InputParser[T] = NoOpParser[Input, T]
 }
 

--- a/cask/src/cask/main/Decorators.scala
+++ b/cask/src/cask/main/Decorators.scala
@@ -1,6 +1,6 @@
 package cask.main
 
-import cask.internal.Router
+import cask.internal.{Conversion, Router}
 import cask.internal.Router.ArgReader
 import cask.model.{Request, Response}
 
@@ -36,7 +36,10 @@ trait BaseEndpoint extends BaseDecorator{
     */
   def subpath: Boolean = false
 
-  def convertToResultType(t: InnerReturned): InnerReturned = t
+  def convertToResultType[T](t: T)
+                            (implicit f: Conversion[T, InnerReturned]): InnerReturned = {
+    f.f(t)
+  }
 
   /**
     * [[Endpoint]]s are unique among decorators in that they alone can bind

--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -48,7 +48,7 @@ abstract class BaseMain{
       )
     }.toMap
 
-  def writeResponse(exchange: HttpServerExchange, response: Response) = {
+  def writeResponse(exchange: HttpServerExchange, response: Response.Raw) = {
     response.headers.foreach{case (k, v) =>
       exchange.getResponseHeaders.put(new HttpString(k), v)
     }
@@ -58,7 +58,7 @@ abstract class BaseMain{
     response.data.write(exchange.getOutputStream)
   }
 
-  def handleNotFound(): Response = {
+  def handleNotFound(): Response.Raw = {
     Response(
       s"Error 404: ${Status.codesToStatus(404).reason}",
       statusCode = 404
@@ -68,19 +68,20 @@ abstract class BaseMain{
 
   def defaultHandler = new BlockingHandler(
     new HttpHandler() {
-      def handleRequest(exchange: HttpServerExchange): Unit = {
+      def handleRequest(exchange: HttpServerExchange): Unit = try {
+//        println("Handling Request: " + exchange.getRequestPath)
         val (effectiveMethod, runner) = if (exchange.getRequestHeaders.getFirst("Upgrade") == "websocket") {
           "websocket" -> ((r: Any) =>
             r.asInstanceOf[WebsocketResult] match{
               case l: WebsocketResult.Listener =>
                 io.undertow.Handlers.websocket(l.value).handleRequest(exchange)
-              case r: WebsocketResult.Response =>
+              case r: WebsocketResult.Response[_] =>
                 writeResponseHandler(r).handleRequest(exchange)
             }
-            )
+          )
         } else (
           exchange.getRequestMethod.toString.toLowerCase(),
-          (r: Any) => writeResponse(exchange, r.asInstanceOf[Response])
+          (r: Any) => writeResponse(exchange, r.asInstanceOf[Response.Raw])
         )
 
         routeTries(effectiveMethod).lookup(Util.splitPath(exchange.getRequestPath).toList, Map()) match {
@@ -93,7 +94,7 @@ abstract class BaseMain{
                 case head :: rest =>
                   head.wrapFunction(
                     ctx,
-                    args => rec(rest, args :: bindings).asInstanceOf[Router.Result[head.Output]]
+                    args => rec(rest, args :: bindings).asInstanceOf[Router.Result[head.InnerReturned]]
                   )
 
                 case Nil =>
@@ -116,16 +117,21 @@ abstract class BaseMain{
             rec((metadata.decorators ++ routes.decorators ++ mainDecorators).toList, Nil)match{
               case Router.Result.Success(res) => runner(res)
               case e: Router.Result.Error =>
-                writeResponse(exchange, handleEndpointError(exchange, routes, metadata, e))
+                writeResponse(
+                  exchange,
+                  handleEndpointError(exchange, routes, metadata, e).map(Response.Data.StringData)
+                )
                 None
             }
         }
-
+//        println("Completed Request: " + exchange.getRequestPath)
+      }catch{case e: Throwable =>
+          e.printStackTrace()
       }
     }
   )
 
-  def writeResponseHandler(r: WebsocketResult.Response) = new BlockingHandler(
+  def writeResponseHandler(r: WebsocketResult.Response[_]) = new BlockingHandler(
     new HttpHandler {
       def handleRequest(exchange: HttpServerExchange): Unit = {
         writeResponse(exchange, r.value)
@@ -142,15 +148,15 @@ abstract class BaseMain{
       case _: Router.Result.Error.InvalidArguments => 400
       case _: Router.Result.Error.MismatchedArguments => 400
     }
-    Response(
+    val str =
       if (!debugMode) s"Error $statusCode: ${Status.codesToStatus(statusCode).reason}"
       else ErrorMsgs.formatInvokeError(
         routes,
         metadata.entryPoint.asInstanceOf[EntryPoint[cask.main.Routes, _]],
         e
-      ),
-      statusCode = statusCode
-    )
+      )
+    println(str)
+    Response(str, statusCode = statusCode)
 
   }
 

--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -28,7 +28,7 @@ class Main(servers0: Routes*) extends BaseMain{
   def allRoutes = servers0.toSeq
 }
 abstract class BaseMain{
-  def mainDecorators = Seq.empty[cask.main.Decorator]
+  def mainDecorators = Seq.empty[cask.main.RawDecorator]
   def allRoutes: Seq[Routes]
   def port: Int = 8080
   def host: String = "localhost"
@@ -88,7 +88,7 @@ abstract class BaseMain{
           case None => writeResponse(exchange, handleNotFound())
           case Some(((routes, metadata), routeBindings, remaining)) =>
             val ctx = Request(exchange, remaining)
-            def rec(remaining: List[Decorator],
+            def rec(remaining: List[RawDecorator],
                     bindings: List[Map[String, Any]]): Router.Result[Any] = try {
               remaining match {
                 case head :: rest =>

--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -99,7 +99,7 @@ abstract class BaseMain{
                   )
 
                 case Nil =>
-                  metadata.endpoint.wrapFunction(ctx, endpointBindings =>
+                  metadata.endpoint.wrapFunction(ctx, (endpointBindings: Map[String, Any]) =>
                     metadata.entryPoint
                       .asInstanceOf[EntryPoint[cask.main.Routes, cask.model.Request]]
                       .invoke(

--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -94,7 +94,8 @@ abstract class BaseMain{
                 case head :: rest =>
                   head.wrapFunction(
                     ctx,
-                    args => rec(rest, args :: bindings).asInstanceOf[Router.Result[head.InnerReturned]]
+                    args => rec(rest, args :: bindings)
+                      .asInstanceOf[cask.internal.Router.Result[cask.model.Response.Raw]]
                   )
 
                 case Nil =>

--- a/cask/src/cask/main/Routes.scala
+++ b/cask/src/cask/main/Routes.scala
@@ -8,7 +8,7 @@ import language.experimental.macros
 
 object Routes{
   case class EndpointMetadata[T](decorators: Seq[Decorator],
-                                 endpoint: BaseEndpoint[_],
+                                 endpoint: BaseEndpoint[_, _],
                                  entryPoint: EntryPoint[T, _])
   case class RoutesEndpointsMetadata[T](value: EndpointMetadata[T]*)
   object RoutesEndpointsMetadata{
@@ -19,15 +19,15 @@ object Routes{
 
       val routeParts = for{
         m <- c.weakTypeOf[T].members
-        val annotations = m.annotations.filter(_.tree.tpe <:< c.weakTypeOf[BaseDecorator[_]]).reverse
+        val annotations = m.annotations.filter(_.tree.tpe <:< c.weakTypeOf[BaseDecorator[_, _]]).reverse
         if annotations.nonEmpty
       } yield {
-        if(!(annotations.head.tree.tpe <:< weakTypeOf[BaseEndpoint[_]])) c.abort(
+        if(!(annotations.head.tree.tpe <:< weakTypeOf[BaseEndpoint[_, _]])) c.abort(
           annotations.head.tree.pos,
           s"Last annotation applied to a function must be an instance of Endpoint, " +
           s"not ${annotations.head.tree.tpe}"
         )
-        val allEndpoints = annotations.filter(_.tree.tpe <:< weakTypeOf[BaseEndpoint[_]])
+        val allEndpoints = annotations.filter(_.tree.tpe <:< weakTypeOf[BaseEndpoint[_, _]])
         if(allEndpoints.length > 1) c.abort(
           annotations.head.tree.pos,
           s"You can only apply one Endpoint annotation to a function, not " +
@@ -45,8 +45,7 @@ object Routes{
           q"${annotObjectSyms.head}.convertToResultType",
           tq"cask.Request",
           annotObjectSyms.map(annotObjectSym => q"$annotObjectSym.getParamParser"),
-          annotObjectSyms.map(annotObjectSym => tq"$annotObjectSym.Input")
-
+          annotObjectSyms.map(annotObjectSym => tq"$annotObjectSym.InputTypeAlias")
         )
 
         val declarations =

--- a/cask/src/cask/main/Routes.scala
+++ b/cask/src/cask/main/Routes.scala
@@ -7,8 +7,8 @@ import scala.reflect.macros.blackbox.Context
 import language.experimental.macros
 
 object Routes{
-  case class EndpointMetadata[T](decorators: Seq[Decorator],
-                                 endpoint: BaseEndpoint[_, _],
+  case class EndpointMetadata[T](decorators: Seq[RawDecorator],
+                                 endpoint: Endpoint[_, _],
                                  entryPoint: EntryPoint[T, _])
   case class RoutesEndpointsMetadata[T](value: EndpointMetadata[T]*)
   object RoutesEndpointsMetadata{
@@ -19,15 +19,15 @@ object Routes{
 
       val routeParts = for{
         m <- c.weakTypeOf[T].members
-        val annotations = m.annotations.filter(_.tree.tpe <:< c.weakTypeOf[BaseDecorator[_, _]]).reverse
+        val annotations = m.annotations.filter(_.tree.tpe <:< c.weakTypeOf[Decorator[_, _]]).reverse
         if annotations.nonEmpty
       } yield {
-        if(!(annotations.head.tree.tpe <:< weakTypeOf[BaseEndpoint[_, _]])) c.abort(
+        if(!(annotations.head.tree.tpe <:< weakTypeOf[Endpoint[_, _]])) c.abort(
           annotations.head.tree.pos,
           s"Last annotation applied to a function must be an instance of Endpoint, " +
           s"not ${annotations.head.tree.tpe}"
         )
-        val allEndpoints = annotations.filter(_.tree.tpe <:< weakTypeOf[BaseEndpoint[_, _]])
+        val allEndpoints = annotations.filter(_.tree.tpe <:< weakTypeOf[Endpoint[_, _]])
         if(allEndpoints.length > 1) c.abort(
           annotations.head.tree.pos,
           s"You can only apply one Endpoint annotation to a function, not " +
@@ -70,7 +70,7 @@ object Routes{
 
 trait Routes{
 
-  def decorators = Seq.empty[cask.main.Decorator]
+  def decorators = Seq.empty[cask.main.RawDecorator]
   private[this] var metadata0: Routes.RoutesEndpointsMetadata[this.type] = null
   def caskMetadata =
     if (metadata0 != null) metadata0

--- a/cask/src/cask/main/Routes.scala
+++ b/cask/src/cask/main/Routes.scala
@@ -8,7 +8,7 @@ import language.experimental.macros
 
 object Routes{
   case class EndpointMetadata[T](decorators: Seq[Decorator],
-                                 endpoint: BaseEndpoint,
+                                 endpoint: BaseEndpoint[_],
                                  entryPoint: EntryPoint[T, _])
   case class RoutesEndpointsMetadata[T](value: EndpointMetadata[T]*)
   object RoutesEndpointsMetadata{
@@ -19,15 +19,15 @@ object Routes{
 
       val routeParts = for{
         m <- c.weakTypeOf[T].members
-        val annotations = m.annotations.filter(_.tree.tpe <:< c.weakTypeOf[BaseDecorator]).reverse
+        val annotations = m.annotations.filter(_.tree.tpe <:< c.weakTypeOf[BaseDecorator[_]]).reverse
         if annotations.nonEmpty
       } yield {
-        if(!(annotations.head.tree.tpe <:< weakTypeOf[BaseEndpoint])) c.abort(
+        if(!(annotations.head.tree.tpe <:< weakTypeOf[BaseEndpoint[_]])) c.abort(
           annotations.head.tree.pos,
           s"Last annotation applied to a function must be an instance of Endpoint, " +
           s"not ${annotations.head.tree.tpe}"
         )
-        val allEndpoints = annotations.filter(_.tree.tpe <:< weakTypeOf[BaseEndpoint])
+        val allEndpoints = annotations.filter(_.tree.tpe <:< weakTypeOf[BaseEndpoint[_]])
         if(allEndpoints.length > 1) c.abort(
           annotations.head.tree.pos,
           s"You can only apply one Endpoint annotation to a function, not " +

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -1,6 +1,6 @@
 package object cask {
   // model
-  type Response = model.Response
+  type Response[T] = model.Response[T]
   val Response = model.Response
   val Abort = model.Abort
   val Redirect = model.Redirect
@@ -29,6 +29,7 @@ package object cask {
   type staticFiles = endpoints.staticFiles
   type staticResources = endpoints.staticResources
   type postJson = endpoints.postJson
+  type getJson = endpoints.getJson
   type postForm = endpoints.postForm
 
   // main

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -38,6 +38,6 @@ package object cask {
   val Routes = main.Routes
   type Main = main.Main
   type Decorator = main.Decorator
-  type Endpoint = main.Endpoint
+  type Endpoint[InnerReturned] = main.Endpoint[InnerReturned]
 
 }

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -38,6 +38,6 @@ package object cask {
   val Routes = main.Routes
   type Main = main.Main
   type Decorator = main.Decorator
-  type Endpoint[InnerReturned] = main.Endpoint[InnerReturned]
+  type Endpoint[InnerReturned, Input] = main.Endpoint[InnerReturned, Input]
 
 }

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -37,7 +37,7 @@ package object cask {
   type Routes = main.Routes
   val Routes = main.Routes
   type Main = main.Main
-  type Decorator = main.Decorator
-  type Endpoint[InnerReturned, Input] = main.Endpoint[InnerReturned, Input]
+  type RawDecorator = main.RawDecorator
+  type HttpEndpoint[InnerReturned, Input] = main.HttpEndpoint[InnerReturned, Input]
 
 }

--- a/cask/test/src/test/cask/FailureTests.scala
+++ b/cask/test/src/test/cask/FailureTests.scala
@@ -4,7 +4,7 @@ import cask.model.Request
 import utest._
 
 object FailureTests extends TestSuite {
-  class myDecorator extends cask.Decorator {
+  class myDecorator extends cask.RawDecorator {
     def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
       delegate(Map("extra" -> 31337))
     }

--- a/cask/test/src/test/cask/FailureTests.scala
+++ b/cask/test/src/test/cask/FailureTests.scala
@@ -5,7 +5,7 @@ import utest._
 
 object FailureTests extends TestSuite {
   class myDecorator extends cask.Decorator {
-    def wrapFunction(ctx: Request, delegate: Delegate): Returned = {
+    def wrapFunction(ctx: Request, delegate: Delegate): OuterReturned = {
       delegate(Map("extra" -> 31337))
     }
   }

--- a/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
+++ b/docs/pages/1 - Cask: a Scala HTTP micro-framework.md
@@ -162,13 +162,13 @@ what to do in each case. You can use the `@cask.route` annotation to do so
 $$$formJsonPost
 
 If you need to handle a JSON-encoded POST request, you can use the
-`@cask.postJson` decorator. This assumes the posted request body is a JSON dict,
-and uses its keys to populate the endpoint's parameters, either as raw
-`ujson.Js.Value`s or deserialized into `Seq[Int]`s or other things.
-Deserialization is handled using the
-[uPickle](https://github.com/lihaoyi/upickle) JSON library, though you could
-write your own version of `postJson` to work with any other JSON library of your
-choice.
+`@cask.postJson` decorator. This assumes the posted request body is a
+JSON dict, and uses its keys to populate the endpoint's parameters,
+either as raw `ujson.Value`s or deserialized into `Seq[Int]`s or other
+things. Deserialization is handled using the
+[uPickle](https://github.com/lihaoyi/upickle) JSON library, though you
+could write your own version of `postJson` to work with any other JSON
+library of your choice.
 
 Similarly, you can mark endpoints as `@cask.postForm`, in which case the
 endpoints params will be taken from the form-encoded POST body either raw (as

--- a/example/compress/app/test/src/ExampleTests.scala
+++ b/example/compress/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Compress - test(Compress){ host =>
+    test("Compress") - withServer(Compress){ host =>
       val expected = "Hello World! Hello World! Hello World!"
       requests.get(s"$host").text() ==> expected
       assert(

--- a/example/compress/build.sc
+++ b/example/compress/build.sc
@@ -10,7 +10,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/compress2/app/test/src/ExampleTests.scala
+++ b/example/compress2/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Compress2Main - test(Compress2Main) { host =>
+    test("Compress2Main") - withServer(Compress2Main) { host =>
       val expected = "Hello World! Hello World! Hello World!"
       requests.get(s"$host").text() ==> expected
       assert(

--- a/example/compress2/build.sc
+++ b/example/compress2/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/compress3/app/test/src/ExampleTests.scala
+++ b/example/compress3/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Compress3Main - test(Compress3Main){ host =>
+    test("Compress3Main") - withServer(Compress3Main){ host =>
       val expected = "Hello World! Hello World! Hello World!"
       requests.get(s"$host").text() ==> expected
       assert(

--- a/example/compress3/build.sc
+++ b/example/compress3/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/cookies/app/test/src/ExampleTests.scala
+++ b/example/cookies/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Cookies - test(Cookies){ host =>
+    test("Cookies") - withServer(Cookies){ host =>
       val sess = requests.Session()
       sess.get(s"$host/read-cookie").statusCode ==> 400
       sess.get(s"$host/store-cookie")

--- a/example/cookies/build.sc
+++ b/example/cookies/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/decorated/app/src/Decorated.scala
+++ b/example/decorated/app/src/Decorated.scala
@@ -3,12 +3,12 @@ object Decorated extends cask.MainRoutes{
   class User{
     override def toString = "[haoyi]"
   }
-  class loggedIn extends cask.Decorator {
+  class loggedIn extends cask.RawDecorator {
     def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("user" -> new User()))
     }
   }
-  class withExtra extends cask.Decorator {
+  class withExtra extends cask.RawDecorator {
     def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("extra" -> 31337))
     }

--- a/example/decorated/app/src/Decorated.scala
+++ b/example/decorated/app/src/Decorated.scala
@@ -4,12 +4,12 @@ object Decorated extends cask.MainRoutes{
     override def toString = "[haoyi]"
   }
   class loggedIn extends cask.Decorator {
-    def wrapFunction(ctx: cask.Request, delegate: Delegate): Returned = {
+    def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("user" -> new User()))
     }
   }
   class withExtra extends cask.Decorator {
-    def wrapFunction(ctx: cask.Request, delegate: Delegate): Returned = {
+    def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("extra" -> 31337))
     }
   }

--- a/example/decorated/app/test/src/ExampleTests.scala
+++ b/example/decorated/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Decorated - test(Decorated){ host =>
+    test("Decorated") - withServer(Decorated){ host =>
       requests.get(s"$host/hello/woo").text() ==> "woo31337"
       requests.get(s"$host/internal/boo").text() ==> "boo[haoyi]"
       requests.get(s"$host/internal-extra/goo").text() ==> "goo[haoyi]31337"

--- a/example/decorated/build.sc
+++ b/example/decorated/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/decorated2/app/src/Decorated2.scala
+++ b/example/decorated2/app/src/Decorated2.scala
@@ -3,12 +3,12 @@ object Decorated2 extends cask.MainRoutes{
   class User{
     override def toString = "[haoyi]"
   }
-  class loggedIn extends cask.Decorator {
+  class loggedIn extends cask.RawDecorator {
     def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("user" -> new User()))
     }
   }
-  class withExtra extends cask.Decorator {
+  class withExtra extends cask.RawDecorator {
     def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("extra" -> 31337))
     }

--- a/example/decorated2/app/src/Decorated2.scala
+++ b/example/decorated2/app/src/Decorated2.scala
@@ -4,12 +4,12 @@ object Decorated2 extends cask.MainRoutes{
     override def toString = "[haoyi]"
   }
   class loggedIn extends cask.Decorator {
-    def wrapFunction(ctx: cask.Request, delegate: Delegate): Returned = {
+    def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("user" -> new User()))
     }
   }
   class withExtra extends cask.Decorator {
-    def wrapFunction(ctx: cask.Request, delegate: Delegate): Returned = {
+    def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
       delegate(Map("extra" -> 31337))
     }
   }

--- a/example/decorated2/app/test/src/ExampleTests.scala
+++ b/example/decorated2/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Decorated2 - test(Decorated2){ host =>
+    test("Decorated2") - withServer(Decorated2){ host =>
       requests.get(s"$host/hello/woo").text() ==> "woo31337"
       requests.get(s"$host/internal-extra/goo").text() ==> "goo[haoyi]31337"
       requests.get(s"$host/ignore-extra/boo").text() ==> "boo[haoyi]"

--- a/example/decorated2/build.sc
+++ b/example/decorated2/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/endpoints/app/src/Endpoints.scala
+++ b/example/endpoints/app/src/Endpoints.scala
@@ -1,7 +1,7 @@
 package app
 
-class custom(val path: String, val methods: Seq[String]) extends cask.Endpoint[Int]{
-  type Output = Int
+class custom(val path: String, val methods: Seq[String])
+  extends cask.Endpoint[Int, Seq[String]]{
   def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
     delegate(Map()).map{num =>
       cask.Response("Echo " + num, statusCode = num)
@@ -10,7 +10,6 @@ class custom(val path: String, val methods: Seq[String]) extends cask.Endpoint[I
 
   def wrapPathSegment(s: String) = Seq(s)
 
-  type Input = Seq[String]
   type InputParser[T] = cask.endpoints.QueryParamReader[T]
 }
 

--- a/example/endpoints/app/src/Endpoints.scala
+++ b/example/endpoints/app/src/Endpoints.scala
@@ -2,7 +2,8 @@ package app
 
 class custom(val path: String, val methods: Seq[String]) extends cask.Endpoint{
   type Output = Int
-  def wrapFunction(ctx: cask.Request, delegate: Delegate): Returned = {
+  type InnerReturned = Int
+  def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
     delegate(Map()).map{num =>
       cask.Response("Echo " + num, statusCode = num)
     }

--- a/example/endpoints/app/src/Endpoints.scala
+++ b/example/endpoints/app/src/Endpoints.scala
@@ -1,7 +1,7 @@
 package app
 
 class custom(val path: String, val methods: Seq[String])
-  extends cask.Endpoint[Int, Seq[String]]{
+  extends cask.HttpEndpoint[Int, Seq[String]]{
   def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
     delegate(Map()).map{num =>
       cask.Response("Echo " + num, statusCode = num)

--- a/example/endpoints/app/src/Endpoints.scala
+++ b/example/endpoints/app/src/Endpoints.scala
@@ -1,8 +1,7 @@
 package app
 
-class custom(val path: String, val methods: Seq[String]) extends cask.Endpoint{
+class custom(val path: String, val methods: Seq[String]) extends cask.Endpoint[Int]{
   type Output = Int
-  type InnerReturned = Int
   def wrapFunction(ctx: cask.Request, delegate: Delegate): OuterReturned = {
     delegate(Map()).map{num =>
       cask.Response("Echo " + num, statusCode = num)

--- a/example/endpoints/app/test/src/ExampleTests.scala
+++ b/example/endpoints/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Endpoints - test(Endpoints){ host =>
+    test("Endpoints") - withServer(Endpoints){ host =>
       requests.get(s"$host/echo/200").text() ==> "Echo 200"
       requests.get(s"$host/echo/200").statusCode ==> 200
       requests.get(s"$host/echo/400").text() ==> "Echo 400"

--- a/example/endpoints/build.sc
+++ b/example/endpoints/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/formJsonPost/app/src/FormJsonPost.scala
+++ b/example/formJsonPost/app/src/FormJsonPost.scala
@@ -1,10 +1,7 @@
 package app
-
-import java.io.ByteArrayInputStream
-
 object FormJsonPost extends cask.MainRoutes{
   @cask.postJson("/json")
-  def jsonEndpoint(value1: ujson.Js.Value, value2: Seq[Int]) = {
+  def jsonEndpoint(value1: ujson.Value, value2: Seq[Int]) = {
     "OK " + value1 + " " + value2
   }
 

--- a/example/formJsonPost/app/src/FormJsonPost.scala
+++ b/example/formJsonPost/app/src/FormJsonPost.scala
@@ -1,4 +1,7 @@
 package app
+
+import java.io.ByteArrayInputStream
+
 object FormJsonPost extends cask.MainRoutes{
   @cask.postJson("/json")
   def jsonEndpoint(value1: ujson.Js.Value, value2: Seq[Int]) = {

--- a/example/formJsonPost/app/test/src/ExampleTests.scala
+++ b/example/formJsonPost/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,23 +17,23 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'FormJsonPost - test(FormJsonPost){ host =>
-      requests.post(s"$host/json", data = """{"value1": true, "value2": [3]}""").text() ==>
-        "OK true List(3)"
+    test("FormJsonPost") - withServer(FormJsonPost){ host =>
+      val response1 = requests.post(s"$host/json", data = """{"value1": true, "value2": [3]}""")
+      ujson.read(response1.text()) ==> ujson.Str("OK true List(3)")
 
-      requests.post(
+      val response2 = requests.post(
         s"$host/form",
         data = Seq("value1" -> "hello", "value2" -> "1", "value2" -> "2")
-      ).text() ==>
-        "OK FormValue(hello,null) List(1, 2)"
+      )
+      response2.text() ==> "OK FormValue(hello,null) List(1, 2)"
 
-      val resp = requests.post(
+      val response3 = requests.post(
         s"$host/upload",
         data = requests.MultiPart(
           requests.MultiItem("image", "...", "my-best-image.txt")
         )
       )
-      resp.text() ==> "my-best-image.txt"
+      response3.text() ==> "my-best-image.txt"
     }
   }
 }

--- a/example/formJsonPost/build.sc
+++ b/example/formJsonPost/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/httpMethods/app/test/src/ExampleTests.scala
+++ b/example/httpMethods/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'HttpMethods - test(HttpMethods){ host =>
+    test("HttpMethods") - withServer(HttpMethods){ host =>
       requests.post(s"$host/login").text() ==> "do_the_login"
       requests.get(s"$host/login").text() ==> "show_the_login_form"
     }

--- a/example/httpMethods/build.sc
+++ b/example/httpMethods/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/minimalApplication/app/test/src/ExampleTests.scala
+++ b/example/minimalApplication/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests {
-    'MinimalApplication - test(MinimalApplication) { host =>
+    test("MinimalApplication") - withServer(MinimalApplication) { host =>
       val success = requests.get(host)
 
       success.text() ==> "Hello World!"

--- a/example/minimalApplication/build.sc
+++ b/example/minimalApplication/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/minimalApplication2/app/test/src/ExampleTests.scala
+++ b/example/minimalApplication2/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'MinimalApplication2 - test(MinimalMain){ host =>
+    test("MinimalApplication2") - withServer(MinimalMain){ host =>
       val success = requests.get(host)
 
       success.text() ==> "Hello World!"

--- a/example/minimalApplication2/build.sc
+++ b/example/minimalApplication2/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/redirectAbort/app/test/src/ExampleTests.scala
+++ b/example/redirectAbort/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -18,7 +18,7 @@ object ExampleTests extends TestSuite{
 
   val tests = Tests{
 
-    'RedirectAbort - test(RedirectAbort){ host =>
+    test("RedirectAbort") - withServer(RedirectAbort){ host =>
       val resp = requests.get(s"$host/")
       resp.statusCode ==> 401
       resp.history.get.statusCode ==> 301

--- a/example/redirectAbort/build.sc
+++ b/example/redirectAbort/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/scalatags/app/test/src/ExampleTests.scala
+++ b/example/scalatags/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests {
-    'Scalatags - test(Scalatags) { host =>
+    test("Scalatags") - withServer(Scalatags) { host =>
       val body = requests.get(host).text()
 
       assert(

--- a/example/scalatags/build.sc
+++ b/example/scalatags/build.sc
@@ -11,7 +11,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/staticFiles/app/test/src/ExampleTests.scala
+++ b/example/staticFiles/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -18,7 +18,7 @@ object ExampleTests extends TestSuite{
 
   val tests = Tests{
 
-    'StaticFiles - test(StaticFiles){ host =>
+    test("StaticFiles") - withServer(StaticFiles){ host =>
       requests.get(s"$host/static/file/example.txt").text() ==>
         "the quick brown fox jumps over the lazy dog"
 

--- a/example/staticFiles/build.sc
+++ b/example/staticFiles/build.sc
@@ -11,7 +11,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
 

--- a/example/todo/app/src/TodoServer.scala
+++ b/example/todo/app/src/TodoServer.scala
@@ -17,7 +17,7 @@ object TodoServer extends cask.MainRoutes{
 
   class transactional extends cask.Decorator{
     class TransactionFailed(val value: Router.Result.Error) extends Exception
-    def wrapFunction(pctx: cask.Request, delegate: Delegate): Returned = {
+    def wrapFunction(pctx: cask.Request, delegate: Delegate): OuterReturned = {
       try ctx.transaction(
         delegate(Map()) match{
           case Router.Result.Success(t) => Router.Result.Success(t)

--- a/example/todo/app/test/src/ExampleTests.scala
+++ b/example/todo/app/test/src/ExampleTests.scala
@@ -1,7 +1,7 @@
 package app
 import utest._
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = io.undertow.Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -13,7 +13,7 @@ object ExampleTests extends TestSuite{
     res
   }
   val tests = Tests{
-    'TodoServer - test(TodoServer){ host =>
+    test("TodoServer") - withServer(TodoServer){ host =>
       val page = requests.get(host).text()
       assert(page.contains("What needs to be done?"))
     }

--- a/example/todo/build.sc
+++ b/example/todo/build.sc
@@ -13,7 +13,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/todoApi/app/test/src/ExampleTests.scala
+++ b/example/todoApi/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'TodoMvcApi - test(TodoMvcApi){ host =>
+    test("TodoMvcApi") - withServer(TodoMvcApi){ host =>
       requests.get(s"$host/list/all").text() ==>
         """[{"checked":true,"text":"Get started with Cask"},{"checked":false,"text":"Profit!"}]"""
       requests.get(s"$host/list/active").text() ==>

--- a/example/todoApi/build.sc
+++ b/example/todoApi/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/todoDb/app/src/TodoMvcDb.scala
+++ b/example/todoDb/app/src/TodoMvcDb.scala
@@ -16,7 +16,7 @@ object TodoMvcDb extends cask.MainRoutes{
 
   class transactional extends cask.Decorator{
     class TransactionFailed(val value: Router.Result.Error) extends Exception
-    def wrapFunction(pctx: cask.Request, delegate: Delegate): Returned = {
+    def wrapFunction(pctx: cask.Request, delegate: Delegate): OuterReturned = {
       try ctx.transaction(
         delegate(Map()) match{
           case Router.Result.Success(t) => Router.Result.Success(t)

--- a/example/todoDb/app/test/src/ExampleTests.scala
+++ b/example/todoDb/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'TodoMvcDb - test(TodoMvcDb){ host =>
+    test("TodoMvcDb") - withServer(TodoMvcDb){ host =>
       requests.get(s"$host/list/all").text() ==>
         """[{"id":1,"checked":true,"text":"Get started with Cask"},{"id":2,"checked":false,"text":"Profit!"}]"""
       requests.get(s"$host/list/active").text() ==>

--- a/example/todoDb/build.sc
+++ b/example/todoDb/build.sc
@@ -12,7 +12,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/twirl/app/test/src/ExampleTests.scala
+++ b/example/twirl/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests {
-    'Twirl - test(Twirl) { host =>
+    test("Twirl") - withServer(Twirl) { host =>
       val body = requests.get(host).text()
 
       assert(

--- a/example/twirl/build.sc
+++ b/example/twirl/build.sc
@@ -15,7 +15,7 @@ trait AppModule extends ScalaModule with mill.twirllib.TwirlModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/variableRoutes/app/test/src/ExampleTests.scala
+++ b/example/variableRoutes/app/test/src/ExampleTests.scala
@@ -4,7 +4,7 @@ import io.undertow.Undertow
 import utest._
 
 object ExampleTests extends TestSuite{
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -17,7 +17,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'VariableRoutes - test(VariableRoutes){ host =>
+    test("VariableRoutes") - withServer(VariableRoutes){ host =>
       val noIndexPage = requests.get(host)
       noIndexPage.statusCode ==> 404
 

--- a/example/variableRoutes/build.sc
+++ b/example/variableRoutes/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
     )
   }

--- a/example/websockets/app/test/src/ExampleTests.scala
+++ b/example/websockets/app/test/src/ExampleTests.scala
@@ -8,7 +8,7 @@ import utest._
 object ExampleTests extends TestSuite{
 
 
-  def test[T](example: cask.main.BaseMain)(f: String => T): T = {
+  def withServer[T](example: cask.main.BaseMain)(f: String => T): T = {
     val server = io.undertow.Undertow.builder
       .addHttpListener(8080, "localhost")
       .setHandler(example.defaultHandler)
@@ -21,7 +21,7 @@ object ExampleTests extends TestSuite{
   }
 
   val tests = Tests{
-    'Websockets - test(Websockets){ host =>
+    test("Websockets") - withServer(Websockets){ host =>
       @volatile var out = List.empty[String]
       val client = org.asynchttpclient.Dsl.asyncHttpClient();
       try{
@@ -72,7 +72,7 @@ object ExampleTests extends TestSuite{
       }
     }
 
-    'Websockets2000 - test(Websockets){ host =>
+    test("Websockets2000") - withServer(Websockets){ host =>
       @volatile var out = List.empty[String]
       val closed = new AtomicInteger(0)
       val client = org.asynchttpclient.Dsl.asyncHttpClient();

--- a/example/websockets/build.sc
+++ b/example/websockets/build.sc
@@ -9,7 +9,7 @@ trait AppModule extends ScalaModule{
     def testFrameworks = Seq("utest.runner.Framework")
 
     def ivyDeps = Agg(
-      ivy"com.lihaoyi::utest::0.6.9",
+      ivy"com.lihaoyi::utest::0.7.1",
       ivy"com.lihaoyi::requests::0.2.0",
       ivy"org.asynchttpclient:async-http-client:2.5.2"
     )


### PR DESCRIPTION
- Fix `@cask.postJson` endpoint to properly serialize results as JSON
- Add `@cask.getJson`
- Rename `Output` -> `InnerReturned` and `Returned` -> `OuterReturned`
- Allow serialization of `Unit` `Boolean`s and `Numeric`s in normal endpoints
- Make `cask.Response` generic, and make `postJson` and `getJson` return `Response[postJson.Data]` to provide better error messages