### PR TITLE
Tighten behavior of WebsocketClientImpl

### DIFF
--- a/cask/util/src-js/cask/util/WebsocketClientImpl.scala
+++ b/cask/util/src-js/cask/util/WebsocketClientImpl.scala
@@ -28,6 +28,8 @@ abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
   def onError(ex: Exception): Unit
   def onMessage(value: String): Unit
   def onClose(code: Int, reason: String): Unit
-  def close(): Unit = websocket.close()
+  def close(): Unit = {
+    if (!closed) websocket.close()
+  }
   def isClosed() = closed
 }

--- a/cask/util/src-js/cask/util/WebsocketClientImpl.scala
+++ b/cask/util/src-js/cask/util/WebsocketClientImpl.scala
@@ -7,7 +7,7 @@ abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
   var closed = false
   def connect(): Unit = {
     websocket = new dom.WebSocket(url)
-    closed = false
+    assert(closed == false)
     websocket.onopen = (e: dom.Event) => onOpen()
     websocket.onmessage = (e: dom.MessageEvent) => onMessage(e.data.asInstanceOf[String])
     websocket.onclose = (e: dom.CloseEvent) => {

--- a/cask/util/src-js/cask/util/WebsocketClientImpl.scala
+++ b/cask/util/src-js/cask/util/WebsocketClientImpl.scala
@@ -7,7 +7,7 @@ abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
   var closed = false
   def connect(): Unit = {
     websocket = new dom.WebSocket(url)
-
+    closed = false
     websocket.onopen = (e: dom.Event) => onOpen()
     websocket.onmessage = (e: dom.MessageEvent) => onMessage(e.data.asInstanceOf[String])
     websocket.onclose = (e: dom.CloseEvent) => {

--- a/cask/util/src-jvm/cask/util/WebsocketClientImpl.scala
+++ b/cask/util/src-jvm/cask/util/WebsocketClientImpl.scala
@@ -6,7 +6,7 @@ abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
   var websocket: Client = null
   var closed = false
   def connect(): Unit = {
-    closed = false
+    assert(closed == false)
     websocket = new Client()
     websocket.connect()
   }

--- a/cask/util/src-jvm/cask/util/WebsocketClientImpl.scala
+++ b/cask/util/src-jvm/cask/util/WebsocketClientImpl.scala
@@ -26,7 +26,9 @@ abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
   }
   def onClose(code: Int, reason: String): Unit
   def onError(ex: Exception): Unit
-  def close(): Unit = websocket.close()
+  def close(): Unit = {
+    if (!closed) websocket.close()
+  }
   def isClosed() = websocket.isClosed()
   class Client() extends WebSocketClient(new java.net.URI(url)){
     def onOpen(handshakedata: ServerHandshake) = {

--- a/cask/util/src-jvm/cask/util/WebsocketClientImpl.scala
+++ b/cask/util/src-jvm/cask/util/WebsocketClientImpl.scala
@@ -4,8 +4,9 @@ import org.java_websocket.handshake.ServerHandshake
 
 abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
   var websocket: Client = null
-
+  var closed = false
   def connect(): Unit = {
+    closed = false
     websocket = new Client()
     websocket.connect()
   }
@@ -32,7 +33,10 @@ abstract class WebsocketClientImpl(url: String) extends WebsocketBase{
       WebsocketClientImpl.this.onOpen()
     }
     def onMessage(message: String) = WebsocketClientImpl.this.onMessage(message)
-    def onClose(code: Int, reason: String, remote: Boolean) = WebsocketClientImpl.this.onClose(code, reason)
+    def onClose(code: Int, reason: String, remote: Boolean) = {
+      closed = true
+      WebsocketClientImpl.this.onClose(code, reason)
+    }
     def onError(ex: Exception) = WebsocketClientImpl.this.onError(ex)
 
   }

--- a/cask/util/src/cask/util/WsClient.scala
+++ b/cask/util/src/cask/util/WsClient.scala
@@ -14,6 +14,8 @@ class WsClient(impl: WebsocketBase)
     case Ws.Close(_, _) => impl.close()
     case Ws.ChannelClosed() => impl.close()
   }
+    
+  def close(code: Int = 1005, reason: String = "") = this.send(Ws.Close(code, reason))
 }
 
 object WsClient{

--- a/cask/util/src/cask/util/WsClient.scala
+++ b/cask/util/src/cask/util/WsClient.scala
@@ -14,7 +14,6 @@ class WsClient(impl: WebsocketBase)
     case Ws.Close(_, _) => impl.close()
     case Ws.ChannelClosed() => impl.close()
   }
-  def close() = impl.close()
 }
 
 object WsClient{


### PR DESCRIPTION
- No more synchronous `.close` method; it has to go through `.send` like everyone else

- Check for a `closed` flag before calling `.close()` on the internal impl