### PR TITLE
Add SameSite option to cookies

### DIFF
--- a/cask/src/cask/model/Params.scala
+++ b/cask/src/cask/model/Params.scala
@@ -40,7 +40,8 @@ object Cookie{
       from.getVersion,
       from.isDiscard,
       from.isHttpOnly,
-      from.isSecure
+      from.isSecure,
+      from.getSameSiteMode
     )
   }
   def toUndertow(from: Cookie): io.undertow.server.handlers.Cookie = {
@@ -54,6 +55,7 @@ object Cookie{
     out.setDiscard(from.discard)
     out.setHttpOnly(from.httpOnly)
     out.setSecure(from.secure)
+    out.setSameSiteMode(from.sameSite)
   }
 }
 case class Cookie(name: String,
@@ -66,7 +68,8 @@ case class Cookie(name: String,
                   version: Int = 1,
                   discard: Boolean = false,
                   httpOnly: Boolean = false,
-                  secure: Boolean = false) {
+                  secure: Boolean = false,
+                  sameSite: String = null) {
 
 }
 


### PR DESCRIPTION
This adds the relatively new [SameSite option](https://www.owasp.org/index.php/SameSite) to cookies.

It simply forwards the [SameSite field from undertow](https://github.com/undertow-io/undertow/blob/ff4c9cf37872cb96070ba6a2fcbbaa6df291e390/core/src/main/java/io/undertow/server/handlers/CookieImpl.java#L166).

Modern browsers understand the values "Lax" and "Strict", so this field could also be exposed as an ADT. However, my preference would be to keep it as a string, since it allows future binary compatibility and also is the right abstraction IMO (anything beyond string in the HTTP world is assuming too much).