### PR TITLE
Allow arbitrary HTTP methods

### DIFF
--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -37,6 +37,12 @@ class post(val path: String, override val subpath: Boolean = false) extends WebE
 class put(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
   val methods = Seq("put")
 }
+class patch(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+  val methods = Seq("patch")
+}
+class delete(val path: String, override val subpath: Boolean = false) extends WebEndpoint{
+  val methods = Seq("delete")
+}
 class route(val path: String, val methods: Seq[String], override val subpath: Boolean = false) extends WebEndpoint
 
 abstract class QueryParamReader[T]

--- a/cask/src/cask/main/Main.scala
+++ b/cask/src/cask/main/Main.scala
@@ -120,12 +120,16 @@ object Main{
     )
   }
 
-  def prepareRouteTries(allRoutes: Seq[Routes]) = {
+  def prepareRouteTries(allRoutes: Seq[Routes]): Map[String, DispatchTrie[(Routes, EndpointMetadata[_])]] = {
     val routeList = for{
       routes <- allRoutes
       route <- routes.caskMetadata.value.map(x => x: EndpointMetadata[_])
     } yield (routes, route)
-    Seq("get", "put", "post", "websocket")
+
+    val allMethods: Set[String] =
+      routeList.flatMap(_._2.endpoint.methods).map(_.toLowerCase).toSet
+
+    allMethods
       .map { method =>
         method -> DispatchTrie.construct[(Routes, EndpointMetadata[_])](0,
           for ((route, metadata) <- routeList if metadata.endpoint.methods.contains(method))

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -27,6 +27,8 @@ package object cask {
   type get = endpoints.get
   type post = endpoints.post
   type put = endpoints.put
+  type delete = endpoints.delete
+  type patch = endpoints.patch
   type route = endpoints.route
   type staticFiles = endpoints.staticFiles
   type staticResources = endpoints.staticResources

--- a/example/httpMethods/app/src/HttpMethods.scala
+++ b/example/httpMethods/app/src/HttpMethods.scala
@@ -6,5 +6,15 @@ object HttpMethods extends cask.MainRoutes{
     else "show_the_login_form"
   }
 
+  @cask.route("/session", methods = Seq("delete"))
+  def session(request: cask.Request) = {
+    "delete_the_session"
+  }
+
+  @cask.route("/session", methods = Seq("secretmethod"))
+  def admin(request: cask.Request) = {
+    "security_by_obscurity"
+  }
+
   initialize()
 }

--- a/example/httpMethods/app/test/src/ExampleTests.scala
+++ b/example/httpMethods/app/test/src/ExampleTests.scala
@@ -20,6 +20,8 @@ object ExampleTests extends TestSuite{
     test("HttpMethods") - withServer(HttpMethods){ host =>
       requests.post(s"$host/login").text() ==> "do_the_login"
       requests.get(s"$host/login").text() ==> "show_the_login_form"
+      requests.delete(s"$host/session").text() ==> "delete_the_session"
+      requests.get.copy(verb="secretmethod")(s"$host/session").text() ==> "security_by_obscurity"
     }
   }
 }


### PR DESCRIPTION
This enables users to define custom HTTP methods in `cask.request` endpoints.

Previously, although that decorator allowed arbitrary methods, the dispatching triemap would only allow "get", "put", "post" and "websocket". This led to runtime errors when trying to access a "delete" endpoint, for example.