### PR TITLE
Optionally allow unknown arguments

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -8,6 +8,7 @@ import $file.example.cookies.build
 import $file.example.decorated.build
 import $file.example.decorated2.build
 import $file.example.endpoints.build
+import $file.example.extraParams.build
 import $file.example.formJsonPost.build
 import $file.example.httpMethods.build
 import $file.example.minimalApplication.build
@@ -111,6 +112,7 @@ object example extends Module{
   object decorated extends $file.example.decorated.build.AppModule with LocalModule
   object decorated2 extends $file.example.decorated2.build.AppModule with LocalModule
   object endpoints extends $file.example.endpoints.build.AppModule with LocalModule
+  object extraParams extends $file.example.extraParams.build.AppModule with LocalModule
   object formJsonPost extends $file.example.formJsonPost.build.AppModule with LocalModule
   object httpMethods extends $file.example.httpMethods.build.AppModule with LocalModule
   object minimalApplication extends $file.example.minimalApplication.build.AppModule with LocalModule
@@ -157,6 +159,7 @@ def uploadToGithub(authKey: String) = T.command{
     $file.example.decorated.build.millSourcePath,
     $file.example.decorated2.build.millSourcePath,
     $file.example.endpoints.build.millSourcePath,
+    $file.example.extraParams.build.millSourcePath,
     $file.example.formJsonPost.build.millSourcePath,
     $file.example.httpMethods.build.millSourcePath,
     $file.example.minimalApplication.build.millSourcePath,

--- a/cask/src/cask/endpoints/ParamReader.scala
+++ b/cask/src/cask/endpoints/ParamReader.scala
@@ -1,7 +1,7 @@
 package cask.endpoints
 
 import cask.router.ArgReader
-import cask.model.{Cookie, Request}
+import cask.model.{Cookie, Query, Request}
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.form.{FormData, FormParserFactory}
 
@@ -25,4 +25,11 @@ object ParamReader{
   implicit object CookieParam extends NilParam[Cookie]((ctx, label) =>
     Cookie.fromUndertow(ctx.exchange.getRequestCookies().get(label))
   )
+
+  implicit object QueryParam extends NilParam[Query]((ctx, label) =>
+    Query(ctx.exchange.getQueryString)
+  ) {
+    override def allowUnknownArgs = true
+  }
+
 }

--- a/cask/src/cask/endpoints/WebEndpoints.scala
+++ b/cask/src/cask/endpoints/WebEndpoints.scala
@@ -77,6 +77,7 @@ object QueryParamReader{
     }
   }
   implicit def paramReader[T: ParamReader] = new QueryParamReader[T] {
+    override def allowUnknownArgs = implicitly[ParamReader[T]].allowUnknownArgs
     override def arity = 0
 
     override def read(ctx: cask.model.Request, label: String, v: Seq[String]) = {

--- a/cask/src/cask/model/Params.scala
+++ b/cask/src/cask/model/Params.scala
@@ -111,3 +111,12 @@ case class FormFile(fileName: String,
                     headers: io.undertow.util.HeaderMap) extends FormEntry{
   def valueOrFileName = fileName
 }
+
+/** Use this as a parameter type to get access to the raw query string
+  *
+  * This is useful if you need to deal with raw (and potentially unknown)
+  * HTTP parameters.
+  */
+case class Query(
+  string: String
+)

--- a/cask/src/cask/package.scala
+++ b/cask/src/cask/package.scala
@@ -16,6 +16,8 @@ package object cask {
   val FormFile = model.FormFile
   type Cookie = model.Cookie
   val Cookie = model.Cookie
+  type Query = model.Query
+  val Query = model.Query
   type Request = model.Request
   val Request = model.Request
 

--- a/cask/src/cask/router/Misc.scala
+++ b/cask/src/cask/router/Misc.scala
@@ -18,6 +18,10 @@ case class ArgSig[I, -T, +V, -C](name: String,
                                 (implicit val reads: ArgReader[I, V, C])
 
 trait ArgReader[I, +T, -C]{
+  // Mark this reader as accepting arguments whose arity and names are unknown
+  // ahead of time. Effectively, this requests that the entrypoint ignore
+  // unknown arguments in the parameter list in which this reader is used.
+  def allowUnknownArgs: Boolean = false
   def arity: Int
   def read(ctx: C, label: String, input: I): T
 }

--- a/example/extraParams/app/src/ExtraParams.scala
+++ b/example/extraParams/app/src/ExtraParams.scala
@@ -1,0 +1,11 @@
+package app
+object ExtraParams extends cask.MainRoutes{
+
+  @cask.get("/echo/strict")
+  def echo1(param1: String) = param1
+
+  @cask.get("/echo/lax")
+  def echo2(param1: String, query: cask.Query) = query.string
+
+  initialize()
+}

--- a/example/extraParams/app/test/src/ExampleTests.scala
+++ b/example/extraParams/app/test/src/ExampleTests.scala
@@ -1,0 +1,29 @@
+package app
+import io.undertow.Undertow
+
+import utest._
+
+object ExampleTests extends TestSuite{
+  def withServer[T](example: cask.main.Main)(f: String => T): T = {
+    val server = Undertow.builder
+      .addHttpListener(8081, "localhost")
+      .setHandler(example.defaultHandler)
+      .build
+    server.start()
+    val res =
+      try f("http://localhost:8081")
+      finally server.stop()
+    res
+  }
+
+  val tests = Tests {
+    test("ExtraParams") - withServer(ExtraParams) { host =>
+      requests.get(s"$host/echo/strict?param1=hello").text() ==> "hello"
+      requests.get(s"$host/echo/strict?param1=hello&param2=world", check = false).statusCode ==> 400
+
+      requests.get(s"$host/echo/lax?param1=hello").text() ==> "param1=hello"
+      requests.get(s"$host/echo/lax?param1=hello&param2=world").text() ==>
+        "param1=hello&param2=world"
+    }
+  }
+}

--- a/example/extraParams/build.sc
+++ b/example/extraParams/build.sc
@@ -1,0 +1,16 @@
+import mill._, scalalib._
+
+
+trait AppModule extends ScalaModule{
+  def scalaVersion = "2.13.2"
+  def ivyDeps = Agg[Dep](
+  )
+  object test extends Tests{
+    def testFrameworks = Seq("utest.runner.Framework")
+
+    def ivyDeps = Agg(
+      ivy"com.lihaoyi::utest::0.7.4",
+      ivy"com.lihaoyi::requests::0.6.5",
+    )
+  }
+}


### PR DESCRIPTION
This adds the ability for ArgumentReaders to control whther or not unknown arguments encountered in the entrypoint are considered an error.

The motivating use case is to allow parsing arbitrary query parameters.