### PR TITLE
Upgrade undertow and suppress startup messages

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -50,7 +50,7 @@ trait CaskModule extends CrossScalaModule with PublishModule{
 class CaskMainModule(val crossScalaVersion: String) extends CaskModule {
   def ivyDeps = T{
     Agg(
-      ivy"io.undertow:undertow-core:2.0.13.Final",
+      ivy"io.undertow:undertow-core:2.2.3.Final",
       ivy"com.lihaoyi::upickle:1.2.2"
     ) ++
     (if(!isDotty) Agg(ivy"org.scala-lang:scala-reflect:${scalaVersion()}") else Agg())

--- a/cask/src/cask/model/Params.scala
+++ b/cask/src/cask/model/Params.scala
@@ -81,7 +81,7 @@ case class Cookie(name: String,
                   discard: Boolean = false,
                   httpOnly: Boolean = false,
                   secure: Boolean = false,
-                  sameSite: String = null) {
+                  sameSite: String = "Lax") {
 
 }
 

--- a/example/cookies/app/src/Cookies.scala
+++ b/example/cookies/app/src/Cookies.scala
@@ -9,7 +9,7 @@ object Cookies extends cask.MainRoutes{
   def storeCookies() = {
     cask.Response(
       "Cookies Set!",
-      cookies = Seq(cask.Cookie("username", "the username"))
+      cookies = Seq(cask.Cookie("username", "the_username"))
     )
   }
 

--- a/example/cookies/app/test/src/ExampleTests.scala
+++ b/example/cookies/app/test/src/ExampleTests.scala
@@ -21,7 +21,7 @@ object ExampleTests extends TestSuite{
       val sess = requests.Session()
       sess.get(s"$host/read-cookie", check = false).statusCode ==> 400
       sess.get(s"$host/store-cookie")
-      sess.get(s"$host/read-cookie").text() ==> "the username"
+      sess.get(s"$host/read-cookie").text() ==> "the_username"
       sess.get(s"$host/read-cookie").statusCode ==> 200
       sess.get(s"$host/delete-cookie")
       sess.get(s"$host/read-cookie", check = false).statusCode ==> 400


### PR DESCRIPTION
Commits are independent. Here' the gist:

---

- Undertow's cookie handling changed slightly in this version, which
  prompted two changes:

  1. the SameSite cookie no longer accepts null as an argument. Rather
     than adding conditionals to guard setting, we simply change the
     default SameSite value to 'Lax', as is assumed by modern standards
    anyway https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite:

     > The cookie-sending behavior if SameSite is not specified is SameSite=Lax.
     > Previously the default was that cookies were sent for all requests.
 
  2. it no longer handles spaces in cookie values (unless they are
     quoted). This behavior is actually correct according to
     [RFC2109](https://tools.ietf.org/html/rfc2109), which requires cookie
     values to be quoted if they contain spaces. This change is actually
     transparent to cask, but reveals a minor bug in the
     [requests-scala](https://github.com/lihaoyi/requests-scala/pull/73) library.
     Tests pass locally once this issue is fixed.

- The XNIO framework used by undertow generates a lot of noise when cask
  starts up. These changes introduce a verbosity flag (overridable by the user),
  which slence this noise by default.

  In other words, these changes remove this message from being displayed
  every time cask starts up:

  ```
  Dec 26, 2020 2:37:02 PM io.undertow.Undertow start
  INFO: starting server: Undertow - 2.2.3.Final
  Dec 26, 2020 2:37:02 PM org.xnio.Xnio <clinit>
  INFO: XNIO version 3.8.0.Final
  Dec 26, 2020 2:37:02 PM org.xnio.nio.NioXnio <clinit>
  INFO: XNIO NIO Implementation Version 3.8.0.Final
  Dec 26, 2020 2:37:02 PM org.jboss.threads.Version <clinit>
  INFO: JBoss Threads version 3.1.0.Final
  ```